### PR TITLE
A fix to allow using the controller between chewie players

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -146,12 +146,6 @@ class _ChewiePlayerState extends State<Chewie> {
     }
   }
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
   Future<dynamic> _pushFullScreenWidget(BuildContext context) async {
     final isAndroid = Theme.of(context).platform == TargetPlatform.android;
     final TransitionRoute<Null> route = new PageRouteBuilder<Null>(

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -126,6 +126,12 @@ class _VideoPlayerWithControlsState extends State<PlayerWithControls> {
     }
   }
 
+  @override
+  dispose(){
+    widget.controller.removeListener(_onPlay);
+    super.dispose();
+  }
+
   void _onPlay() {
     if (widget.controller.value.isPlaying) {
       setState(() {


### PR DESCRIPTION
remove _onPlay listener from the controller when the widget is disposed and avoid disposing the controller that I'm not the owner of it - the owner is responsible to invoke dispose() (and potentially reuse it ). 