### PR TITLE
Added CircularProgressIndicator on first launch

### DIFF
--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -57,7 +57,13 @@ class _CupertinoControlsState extends State<CupertinoControls> {
       children: <Widget>[
         _buildTopBar(
             backgroundColor, iconColor, controller, barHeight, buttonPadding),
-        _buildHitArea(),
+        _latestValue != null && !_latestValue.isPlaying &&
+            _latestValue.duration == null || _latestValue.isBuffering ?
+          Expanded(
+            child: Center(
+              child: CircularProgressIndicator(),
+            ),
+          ) : _buildHitArea(),
         _buildBottomBar(backgroundColor, iconColor, controller, barHeight),
       ],
     );

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -44,7 +44,13 @@ class _MaterialControlsState extends State<MaterialControls> {
   Widget build(BuildContext context) {
     return new Column(
       children: <Widget>[
-        _buildHitArea(),
+        _latestValue != null && !_latestValue.isPlaying &&
+            _latestValue.duration == null || _latestValue.isBuffering ?
+          Expanded(
+            child: Center(
+              child: CircularProgressIndicator(),
+            ),
+          ) : _buildHitArea(),
         _buildBottomBar(context, widget.controller),
       ],
     );


### PR DESCRIPTION
Slow loading videos will just show an empty progress bar which is irritating for most users. This adds a [CircularProgressIndicator](https://docs.flutter.io/flutter/material/CircularProgressIndicator-class.html) on first buffering.