### PR TITLE
resolves video_player version & adds support for starting video on fullscreen 

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -75,6 +75,7 @@ class Chewie extends StatefulWidget {
 
 class _ChewiePlayerState extends State<Chewie> {
   VideoPlayerController _controller;
+  bool _isFullScreen = false;
 
   @override
   Widget build(BuildContext context) {
@@ -136,6 +137,11 @@ class _ChewiePlayerState extends State<Chewie> {
     }
 
     if (widget.autoPlay) {
+      if (widget.fullScreenByDefault) {
+        _isFullScreen = true;
+        await _pushFullScreenWidget(context);
+      }
+
       await _controller.play();
     }
 
@@ -144,7 +150,12 @@ class _ChewiePlayerState extends State<Chewie> {
     }
 
     if (widget.fullScreenByDefault) {
-      await _pushFullScreenWidget(context);
+      widget.controller.addListener(() async {
+        if (await widget.controller.value.isPlaying && !_isFullScreen) {
+          _isFullScreen = true;
+          await _pushFullScreenWidget(context);
+        }
+      });
     }
   }
 
@@ -155,6 +166,7 @@ class _ChewiePlayerState extends State<Chewie> {
     if (widget.controller.dataSource != _controller.dataSource) {
       _controller.dispose();
       _controller = widget.controller;
+      _isFullScreen = false;
       _initialize();
     }
   }

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -48,6 +48,9 @@ class Chewie extends StatefulWidget {
   /// or played.
   final Widget placeholder;
 
+  /// Defines if the player will start in fullscreen when play is pressed
+  final bool fullScreenByDefault;
+
   Chewie(
     this.controller, {
     Key key,
@@ -56,12 +59,12 @@ class Chewie extends StatefulWidget {
     this.autoPlay = false,
     this.startAt,
     this.looping = false,
+    this.fullScreenByDefault = false,
     this.cupertinoProgressColors,
     this.materialProgressColors,
     this.placeholder,
     this.showControls = true,
-  })  : assert(controller != null,
-            'You must provide a controller to play a video'),
+  })  : assert(controller != null, 'You must provide a controller to play a video'),
         super(key: key);
 
   @override
@@ -94,8 +97,7 @@ class _ChewiePlayerState extends State<Chewie> {
     _initialize();
   }
 
-  Widget _buildFullScreenVideo(
-      BuildContext context, Animation<double> animation) {
+  Widget _buildFullScreenVideo(BuildContext context, Animation<double> animation) {
     return new Scaffold(
       resizeToAvoidBottomPadding: false,
       body: new Container(
@@ -103,8 +105,7 @@ class _ChewiePlayerState extends State<Chewie> {
         color: Colors.black,
         child: new PlayerWithControls(
           controller: _controller,
-          onExpandCollapse: () =>
-              new Future<dynamic>.value(Navigator.of(context).pop()),
+          onExpandCollapse: () => new Future<dynamic>.value(Navigator.of(context).pop()),
           aspectRatio: widget.aspectRatio ?? _calculateAspectRatio(context),
           fullScreen: true,
           cupertinoProgressColors: widget.cupertinoProgressColors,
@@ -140,6 +141,10 @@ class _ChewiePlayerState extends State<Chewie> {
 
     if (widget.startAt != null) {
       await _controller.seekTo(widget.startAt);
+    }
+
+    if (widget.fullScreenByDefault) {
+      await _pushFullScreenWidget(context);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
-  video_player: ">=0.6.0 <0.7.0"
+  video_player: "<=0.6.4"
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
-  video_player: "<=0.6.4"
+  video_player: "<=0.6.4" # video_player should stay at 0.6.4 due to a bug that prevents video rendering with chewie
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
-  video_player: "<=0.6.4" # video_player should stay at 0.6.4 due to a bug that prevents video rendering with chewie
+  video_player: ">= 0.6.0 <=0.6.4" # video_player should stay at 0.6.4 due to a bug that prevents video rendering with chewie
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
-  video_player: ">= 0.6.0 <=0.6.4" # video_player should stay at 0.6.4 due to a bug that prevents video rendering with chewie
+  video_player: ">= 0.6.0 <0.6.4" # video_player should stay at 0.6.4 due to a bug that prevents video rendering with chewie
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This PR will:
- Keep the `video_player` version below 0.6.4 which is fine for video rendering since there is a known issue with 0.6.5 that prevents frames to be shown unless the video enters in full screen and then disposes back to inline.
- Adds a property to choose whether the video should start on full screen or not when the playback starts. 