### PR TITLE
Update to video_player >=0.7.0 <0.8.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
-  video_player: ">=0.6.0 <0.7.0"
+  video_player: ">=0.7.0 <0.8.0"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
An updated version of video_player was released on Oct. 17 with some bug fixes. I have upgraded Chewie to support this latest version.