### PR TITLE
Added options for live and screen sleep

### DIFF
--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -18,6 +18,7 @@ class CupertinoControls extends StatefulWidget {
   final bool fullScreen;
   final ChewieProgressColors progressColors;
   final bool autoPlay;
+  final bool isLive;
 
   CupertinoControls({
     @required this.backgroundColor,
@@ -27,6 +28,7 @@ class CupertinoControls extends StatefulWidget {
     @required this.fullScreen,
     @required this.progressColors,
     @required this.autoPlay,
+    @required this.isLive,
   });
 
   @override
@@ -120,19 +122,37 @@ class _CupertinoControlsState extends State<CupertinoControls> {
                   new Radius.circular(10.0),
                 ),
               ),
-              child: new Row(
-                children: <Widget>[
-                  _buildSkipBack(iconColor, barHeight),
-                  _buildPlayPause(controller, iconColor, barHeight),
-                  _buildSkipForward(iconColor, barHeight),
-                  _buildPosition(iconColor),
-                  _buildProgressBar(),
-                  _buildRemaining(iconColor)
-                ],
-              ),
+              child: widget.isLive
+                  ? Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        _buildPlayPause(controller, iconColor, barHeight),
+                        _buildLive(iconColor),
+                      ],
+                    )
+                  : new Row(
+                      children: <Widget>[
+                        _buildSkipBack(iconColor, barHeight),
+                        _buildPlayPause(controller, iconColor, barHeight),
+                        _buildSkipForward(iconColor, barHeight),
+                        _buildPosition(iconColor),
+                        _buildProgressBar(),
+                        _buildRemaining(iconColor)
+                      ],
+                    ),
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildLive(Color iconColor) {
+    return new Padding(
+      padding: new EdgeInsets.only(right: 12.0),
+      child: new Text(
+        'LIVE',
+        style: new TextStyle(color: iconColor, fontSize: 12.0),
       ),
     );
   }

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -105,7 +105,9 @@ class _MaterialControlsState extends State<MaterialControls> {
         child: new Row(
           children: <Widget>[
             _buildPlayPause(controller),
-            widget.isLive ? const Text('LIVE') : _buildPosition(iconColor),
+            widget.isLive
+                ? Expanded(child: const Text('LIVE'))
+                : _buildPosition(iconColor),
             widget.isLive ? const SizedBox() : _buildProgressBar(),
             _buildMuteButton(controller),
             _buildExpandButton(),

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -13,6 +13,7 @@ class MaterialControls extends StatefulWidget {
   final Future<dynamic> Function() onExpandCollapse;
   final ChewieProgressColors progressColors;
   final bool autoPlay;
+  final bool isLive;
 
   MaterialControls({
     @required this.controller,
@@ -20,6 +21,7 @@ class MaterialControls extends StatefulWidget {
     @required this.onExpandCollapse,
     @required this.progressColors,
     @required this.autoPlay,
+    @required this.isLive,
   });
 
   @override
@@ -103,8 +105,8 @@ class _MaterialControlsState extends State<MaterialControls> {
         child: new Row(
           children: <Widget>[
             _buildPlayPause(controller),
-            _buildPosition(iconColor),
-            _buildProgressBar(),
+            widget.isLive ? const Text('LIVE') : _buildPosition(iconColor),
+            widget.isLive ? const SizedBox() : _buildProgressBar(),
             _buildMuteButton(controller),
             _buildExpandButton(),
           ],

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -99,6 +99,7 @@ class _VideoPlayerWithControlsState extends State<PlayerWithControls> {
                 fullScreen: widget.fullScreen,
                 progressColors: widget.cupertinoProgressColors,
                 autoPlay: widget.autoPlay,
+                isLive: widget.isLive,
               )
         : new Container();
   }

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -18,6 +18,7 @@ class PlayerWithControls extends StatefulWidget {
   final double aspectRatio;
   final bool autoPlay;
   final bool showControls;
+  final bool isLive;
 
   PlayerWithControls({
     Key key,
@@ -30,6 +31,7 @@ class PlayerWithControls extends StatefulWidget {
     this.materialProgressColors,
     this.placeholder,
     this.autoPlay,
+    this.isLive = false,
   }) : super(key: key);
 
   @override
@@ -47,9 +49,9 @@ class _VideoPlayerWithControlsState extends State<PlayerWithControls> {
       child: new Container(
         width: MediaQuery.of(context).size.width,
         child: new AspectRatio(
-                aspectRatio: widget.aspectRatio,
-                child: _buildPlayerWithControls(controller, context),
-              ),
+          aspectRatio: widget.aspectRatio,
+          child: _buildPlayerWithControls(controller, context),
+        ),
       ),
     );
   }
@@ -64,9 +66,9 @@ class _VideoPlayerWithControlsState extends State<PlayerWithControls> {
             child: new Hero(
               tag: controller,
               child: new AspectRatio(
-                      aspectRatio: widget.aspectRatio,
-                      child: new VideoPlayer(controller),
-                    ),
+                aspectRatio: widget.aspectRatio,
+                child: new VideoPlayer(controller),
+              ),
             ),
           ),
           _buildControls(context, controller),
@@ -87,6 +89,7 @@ class _VideoPlayerWithControlsState extends State<PlayerWithControls> {
                 fullScreen: widget.fullScreen,
                 progressColors: widget.materialProgressColors,
                 autoPlay: widget.autoPlay,
+                isLive: widget.isLive,
               )
             : new CupertinoControls(
                 backgroundColor: new Color.fromRGBO(41, 41, 41, 0.7),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
   video_player: ">=0.7.0 <0.8.0"
+  screen: ">=0.0.4 <0.1.0"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
In this PR I've added two options to hide time and progress bar which is called "isLive" and another one to allow keep device screen on while in full screen (allowedScreenSleep).
Issues: #64 #44 