### PR TITLE
Correct video link in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import 'package:chewie/chewie.dart';
 
 final playerWidget = new Chewie(
   new VideoPlayerController.network(
-    'https://flutter.github.io/assets-for-api-docs/videos/butterfly.mp4'
+    'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4'
   ),
   aspectRatio: 3 / 2,
   autoPlay: true,


### PR DESCRIPTION
Video link was moved. Corrected it.