### PR TITLE
Dispose VideoPlayerController when Widget is disposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import 'package:chewie/chewie.dart';
 
 final playerWidget = new Chewie(
   new VideoPlayerController.network(
-    'https://flutter.github.io/assets-for-api-docs/videos/butterfly.mp4'
+    'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4'
   ),
   aspectRatio: 3 / 2,
   autoPlay: true,

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -111,8 +111,8 @@ class _ChewiePlayerState extends State<Chewie> {
   
   @override
   void dispose() {
-    super.dispose();
     _controller.dispose();
+    super.dispose();
   }
 
   Widget _buildFullScreenVideo(

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -108,6 +108,12 @@ class _ChewiePlayerState extends State<Chewie> {
     _controller = widget.controller;
     _initialize();
   }
+  
+  @override
+  void dispose() {
+    super.dispose();
+    _controller.dispose();
+  }
 
   Widget _buildFullScreenVideo(
       BuildContext context, Animation<double> animation) {


### PR DESCRIPTION
Prevents the video from still playing in the background, when ChewieWidget is disposed.

Example:
When I close the view containing the ChewieWidget, e.g. navigate somwhere, the audio can still be heard in the background, since the VideoPlayerController has not been disposed.

Also includes the small Readme link fix from #75 