### PR TITLE
ChewieController.customControls with lazy function support

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -193,7 +193,7 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines customised controls. Check [MaterialControls] or
   /// [CupertinoControls] for reference.
-  final Widget customControls;
+  final dynamic customControls;
 
   /// The Aspect Ratio of the Video. Important to get the correct size of the
   /// video!

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -55,7 +55,7 @@ class PlayerWithControls extends StatelessWidget {
   ) {
     return chewieController.showControls
         ? chewieController.customControls != null
-            ? chewieController.customControls
+            ? (chewieController.customControls is Function ? chewieController.customControls(chewieController) : chewieController.customControls)
             : Theme.of(context).platform == TargetPlatform.android
                 ? MaterialControls()
                 : CupertinoControls(


### PR DESCRIPTION
this pull request add support to this scene: 

customControls is a class widget with access to controller

```
    _chewieController = ChewieController(
        aspectRatio: 16 / 9,
        allowFullScreen: true,
        autoPlay: true,
        allowMuting: false,
        customControls: _buildChewieCustomControls,
        videoPlayerController: _videoPlayerController);

  }

  Widget _buildChewieCustomControls(ChewieController controller) {
    return ChewieCustomControls(controller: controller); // this widget have access to controller
  }
```
