### PR TITLE
fixes #132: only check fullScreenByDefault once

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -302,11 +302,14 @@ class ChewieController extends ChangeNotifier {
     }
 
     if (fullScreenByDefault) {
-      videoPlayerController.addListener(() async {
-        if (videoPlayerController.value.isPlaying && !_isFullScreen) {
-          enterFullScreen();
-        }
-      });
+      videoPlayerController.addListener(_fullScreenListener);
+    }
+  }
+
+  void _fullScreenListener() async {
+    if (videoPlayerController.value.isPlaying && !_isFullScreen) {
+      enterFullScreen();
+      videoPlayerController.removeListener(_fullScreenListener);
     }
   }
 


### PR DESCRIPTION
updated the fullScreenByDefault logic to check on initialization and enter fullScreen and then remove the Listener after executing once. This prevents the listener from firing again on user action.