### PR TITLE
fixes #143 - remove Hero widget

### DIFF
--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -33,13 +33,10 @@ class PlayerWithControls extends StatelessWidget {
         children: <Widget>[
           chewieController.placeholder ?? Container(),
           Center(
-            child: Hero(
-              tag: chewieController.videoPlayerController,
-              child: AspectRatio(
-                aspectRatio: chewieController.aspectRatio ??
-                    _calculateAspectRatio(context),
-                child: VideoPlayer(chewieController.videoPlayerController),
-              ),
+            child: AspectRatio(
+              aspectRatio: chewieController.aspectRatio ??
+                  _calculateAspectRatio(context),
+              child: VideoPlayer(chewieController.videoPlayerController),
             ),
           ),
           chewieController.overlay ?? Container(),


### PR DESCRIPTION
Removes the `Hero` widget from the `player_with_controls.dart` build method to fix #143, allowing Chewie to be used within an external (to Chewie) Hero widget, as you cannot embed Hero widgets.

See: 
- https://github.com/flutter/flutter/issues/1398
- https://github.com/flutter/flutter/pull/28470