### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ In your `pubspec.yaml` file within your Flutter Project:
 ```yaml
 dependencies:
   chewie: <latest_version>
+  video_player: <latest_version>
 ```
 
 ## Use it


### PR DESCRIPTION
Adds the package video_player to the dependencies file. From a superficial point of view, it seems as if the chewie package comes with video_player hence it can be confusing when trying to instantiate `VideoPlayerController` and there's an error.