### PR TITLE
fixes #88 - Replay on play when video finished

### DIFF
--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -149,7 +149,6 @@ class _CupertinoControlsState extends State<CupertinoControls> {
                         _buildRemaining(iconColor)
                       ],
                     ),
-
             ),
           ),
         ),
@@ -489,6 +488,8 @@ class _CupertinoControlsState extends State<CupertinoControls> {
   }
 
   void _playPause() {
+    bool isFinished = _latestValue.position >= _latestValue.duration;
+
     setState(() {
       if (controller.value.isPlaying) {
         _hideStuff = false;
@@ -502,6 +503,9 @@ class _CupertinoControlsState extends State<CupertinoControls> {
             controller.play();
           });
         } else {
+          if (isFinished) {
+            controller.seekTo(Duration(seconds: 0));
+          }
           controller.play();
         }
       }

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -307,6 +307,8 @@ class _MaterialControlsState extends State<MaterialControls> {
   }
 
   void _playPause() {
+    bool isFinished = _latestValue.position >= _latestValue.duration;
+
     setState(() {
       if (controller.value.isPlaying) {
         _hideStuff = false;
@@ -320,6 +322,9 @@ class _MaterialControlsState extends State<MaterialControls> {
             controller.play();
           });
         } else {
+          if (isFinished) {
+            controller.seekTo(Duration(seconds: 0));
+          }
           controller.play();
         }
       }


### PR DESCRIPTION
Fixes the issue with pressing the play button when the video is finished. Before the video player would keep playing even if the video has finished. 

This pr relates to what [#88](https://github.com/brianegan/chewie/issues/88) suggested but does not add a replay button icon. 