### PR TITLE
Switch wakelock plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+* Changed wakelock plugin from `flutter_screen` to `wakelock` due to lack of maintenance of `flutter_screen`. 
+
 ## 0.9.8+1
   * Require latest flutter stable version
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -5,8 +5,8 @@ import 'package:chewie/src/player_with_controls.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:screen/screen.dart';
 import 'package:video_player/video_player.dart';
+import 'package:wakelock/wakelock.dart';
 
 typedef Widget ChewieRoutePageBuilder(
     BuildContext context,
@@ -136,17 +136,16 @@ class ChewieState extends State<Chewie> {
     }
 
     if (!widget.controller.allowedScreenSleep) {
-      Screen.keepOn(true);
+      Wakelock.enable();
     }
 
     await Navigator.of(context).push(route);
     _isFullScreen = false;
     widget.controller.exitFullScreen();
 
-    bool isKeptOn = await Screen.isKeptOn;
-    if (isKeptOn) {
-      Screen.keepOn(false);
-    }
+    // The wakelock plugins checks whether it needs to perform an action internally,
+    // so we do not need to check Wakelock.isEnabled.
+    Wakelock.disable();
 
     SystemChrome.setEnabledSystemUIOverlays(
         widget.controller.systemOverlaysAfterFullScreen);

--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -77,7 +77,8 @@ class _CupertinoControlsState extends State<CupertinoControls> {
           absorbing: _hideStuff,
           child: Column(
             children: <Widget>[
-              _buildTopBar(backgroundColor, iconColor, barHeight, buttonPadding),
+              _buildTopBar(
+                  backgroundColor, iconColor, barHeight, buttonPadding),
               _buildHitArea(),
               _buildBottomBar(backgroundColor, iconColor, barHeight),
             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chewie
 description: A video player for Flutter with Cupertino and Material play controls
-version: 0.9.8+1
+version: 0.9.8+2
 homepage: https://github.com/brianegan/chewie
 authors:
   - Brian Egan <brian@brianegan.com>
@@ -13,7 +13,8 @@ environment:
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
   video_player: ">=0.7.0 <0.11.0"
-  screen: ">=0.0.4 <0.1.0"
+  wakelock: ">0.1.2 <0.2.0"
+
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   open_iconic_flutter: ">=0.3.0 <0.4.0"
   video_player: ">=0.7.0 <0.11.0"
-  wakelock: ">0.1.2 <0.2.0"
+  wakelock: ">=0.1.2 <0.2.0"
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
The current wakelock plugin (`flutter_screen`) lacks maintenance and has had AndroidX compatibility issues for over half a year.

To fix this, I changed the plugin to `wakelock`, which is also more lightweight because it has just the wakelock and no brightness adjustments.

The formatting `cupertino_controls.dart` is caused by `flutter format` and Pub complained about it before.

The version constraint is correct like this and I will ensure that there are no compatibility changes until `0.2.0` as I am the author of [`wakelock`](https://pub.dev/packages/wakelock).

 * Closes #141 (that one is already solved, but including it in this comment will automatically close it upon merging).

## Related

https://github.com/clovisnicolas/flutter_screen/pull/15
