### PR TITLE
Fixed setState() called after dispose() on ProgressBarState and Contr…

### DIFF
--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -39,6 +39,13 @@ class _CupertinoControlsState extends State<CupertinoControls> {
   ChewieController chewieController;
 
   @override
+  void setState(fn) {
+    if(mounted){
+      super.setState(fn);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     chewieController = ChewieController.of(context);
 

--- a/lib/src/cupertino_progress_bar.dart
+++ b/lib/src/cupertino_progress_bar.dart
@@ -25,6 +25,13 @@ class CupertinoVideoProgressBar extends StatefulWidget {
 }
 
 class _VideoProgressBarState extends State<CupertinoVideoProgressBar> {
+  @override
+  void setState(fn) {
+    if(mounted){
+      super.setState(fn);
+    }
+  }
+  
   _VideoProgressBarState() {
     listener = () {
       setState(() {});

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -32,6 +32,13 @@ class _MaterialControlsState extends State<MaterialControls> {
   ChewieController chewieController;
 
   @override
+  void setState(fn) {
+    if(mounted){
+      super.setState(fn);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     if (_latestValue.hasError) {
       return chewieController.errorBuilder != null

--- a/lib/src/material_progress_bar.dart
+++ b/lib/src/material_progress_bar.dart
@@ -25,6 +25,13 @@ class MaterialVideoProgressBar extends StatefulWidget {
 }
 
 class _VideoProgressBarState extends State<MaterialVideoProgressBar> {
+  @override
+  void setState(fn) {
+    if(mounted){
+      super.setState(fn);
+    }
+  }
+  
   _VideoProgressBarState() {
     listener = () {
       setState(() {});


### PR DESCRIPTION
I am working on an app that has the ability to play videos from both online/offline. 

1. Online: VideoPlayerController.network
2. Offline: VideoPlayerController.file 

When switching from offline to online I've got this weird error:
`setState() called after dispose(): _VideoProgressBarState#51ebd(lifecycle state: defunct, not mounted)`

**Solution:**  Override setState method and check if mounted before updating sate

