### PR TITLE
Adds the possibility to set on full screen preferred orientations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.9
+  * Adds the possibility to set on full screen preferred screen orientations.
+
 ## 0.9.8+1
   * Require latest flutter stable version
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -128,11 +128,15 @@ class ChewieState extends State<Chewie> {
     );
 
     SystemChrome.setEnabledSystemUIOverlays([]);
-    if (isAndroid) {
+    final List<DeviceOrientation> fullScreenDeviceOrientations = widget.controller.deviceOrientationsOnFullScreen;
+
+    if (fullScreenDeviceOrientations == null && isAndroid) {
       SystemChrome.setPreferredOrientations([
         DeviceOrientation.landscapeLeft,
         DeviceOrientation.landscapeRight,
       ]);
+    } else if (fullScreenDeviceOrientations?.isNotEmpty ?? false) {
+      SystemChrome.setPreferredOrientations(fullScreenDeviceOrientations);
     }
 
     if (!widget.controller.allowedScreenSleep) {
@@ -193,9 +197,9 @@ class ChewieController extends ChangeNotifier {
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
     ],
+    this.deviceOrientationsOnFullScreen,
     this.routePageBuilder = null,
-  }) : assert(videoPlayerController != null,
-            'You must provide a controller to play a video') {
+  }) : assert(videoPlayerController != null, 'You must provide a controller to play a video') {
     _initialize();
   }
 
@@ -269,6 +273,9 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines the set of allowed device orientations after exiting fullscreen
   final List<DeviceOrientation> deviceOrientationsAfterFullScreen;
+
+  /// Defines the set of allowed device orientations when entering in fullscreen
+  final List<DeviceOrientation> deviceOrientationsOnFullScreen;
 
   /// Defines a custom RoutePageBuilder for the fullscreen
   final ChewieRoutePageBuilder routePageBuilder;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chewie
 description: A video player for Flutter with Cupertino and Material play controls
-version: 0.9.8+1
+version: 0.9.9
 homepage: https://github.com/brianegan/chewie
 authors:
   - Brian Egan <brian@brianegan.com>


### PR DESCRIPTION
Currently developers are restricted to use landscape right or left when in full screen while using an Android device, whereas in iOS it will adapt automatically. This will result in an odd behavior when playing portrait (aspect ratio 9:16 for example) videos.

This will add the `deviceOrientationsOnFullScreen` property that accepts a `List<Orientation>` for full screen playback that will be used for both platforms. If not provided, it will use de default landscape right/left for Android, as it is.