### PR TITLE
User can now set autoPlay to false

### DIFF
--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -496,7 +496,15 @@ class _CupertinoControlsState extends State<CupertinoControls> {
   }
 
   void _playPause() {
-    bool isFinished = _latestValue.position >= _latestValue.duration;
+      bool isFinished;
+      if( _latestValue.duration != null)
+      {
+        isFinished = _latestValue.position >= _latestValue.duration;
+      }
+      else
+      {
+        isFinished = false;
+      }
 
     setState(() {
       if (controller.value.isPlaying) {

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -323,7 +323,15 @@ class _MaterialControlsState extends State<MaterialControls> {
   }
 
   void _playPause() {
-    bool isFinished = _latestValue.position >= _latestValue.duration;
+    bool isFinished;
+    if( _latestValue.duration != null)
+    {
+      isFinished = _latestValue.position >= _latestValue.duration;
+    }
+    else
+    {
+      isFinished = false;
+    }
 
     setState(() {
       if (controller.value.isPlaying) {


### PR DESCRIPTION
fixed issue with setting autoPlay to false. The user can now set autoPlay to false and the video will still be loaded. The issue was that durant was null and couldn't render the video. Another future fix would be to display the play button instead of the loading icon when autoPlay is set to false.