### PR TITLE
Prevent rebuild of MaterialApp

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -124,6 +124,7 @@ class ChewieState extends State<Chewie> {
     final isAndroid = Theme.of(context).platform == TargetPlatform.android;
     final TransitionRoute<Null> route = PageRouteBuilder<Null>(
       settings: RouteSettings(isInitialRoute: false),
+      opaque: false,
       pageBuilder: _fullScreenRoutePageBuilder,
     );
 


### PR DESCRIPTION
PageRouteBuilder need "opaque: false," to prevent unexpected MaterialApp rebuild. 
This commit fix https://github.com/brianegan/chewie/issues/239