### PR TITLE
Check widget is mounted

### DIFF
--- a/lib/src/material_progress_bar.dart
+++ b/lib/src/material_progress_bar.dart
@@ -27,6 +27,7 @@ class MaterialVideoProgressBar extends StatefulWidget {
 class _VideoProgressBarState extends State<MaterialVideoProgressBar> {
   _VideoProgressBarState() {
     listener = () {
+      if (!this.mounted) return;
       setState(() {});
     };
   }


### PR DESCRIPTION
When switching to another widget; the video continued to play on the back and wants to report transactions, but the widget failed because it was not mounted.
For this reason, it is provided to check whether the widget is mounted or not.