### PR TITLE
Export controls in chewie.dart.

### DIFF
--- a/lib/chewie.dart
+++ b/lib/chewie.dart
@@ -1,4 +1,6 @@
 library chewie;
 
+export 'src/material_controls.dart';
+export 'src/cupertino_controls.dart';
 export 'src/chewie_player.dart';
 export 'src/chewie_progress_colors.dart';


### PR DESCRIPTION
I want to use the `MaterialControls` and `CupertinoControls` in customControls parameter.

> _chewieController = ChewieController(
        videoPlayerController: _videoPlayerController,
        aspectRatio: 3 / 2,
        autoInitialize: true,
        customControls: MaterialControls(),
    );

Use `MaterialControls` to avoid this problem(https://github.com/brianegan/chewie/issues/354) on iOS.