### PR TITLE
feat(cupertino_controls): add new skip icons

### DIFF
--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -340,14 +340,10 @@ class _CupertinoControlsState extends State<CupertinoControls> {
           left: 6.0,
           right: 6.0,
         ),
-        child: Transform(
-          alignment: Alignment.center,
-          transform: Matrix4.rotationZ(math.pi * 1.8),
-          child: Icon(
-            Icons.replay,
-            color: iconColor,
-            size: 18.0,
-          ),
+        child: Icon(
+          CupertinoIcons.gobackward_15,
+          color: iconColor,
+          size: 18.0,
         ),
       ),
     );
@@ -366,16 +362,10 @@ class _CupertinoControlsState extends State<CupertinoControls> {
         margin: EdgeInsets.only(
           right: 8.0,
         ),
-        child: Transform(
-          alignment: Alignment.center,
-          transform: Matrix4.skewY(0.0)
-            ..rotateX(math.pi)
-            ..rotateZ(math.pi * 0.8),
-          child: Icon(
-            Icons.replay,
-            color: iconColor,
-            size: 18.0,
-          ),
+        child: Icon(
+          CupertinoIcons.goforward_15,
+          color: iconColor,
+          size: 18.0,
         ),
       ),
     );


### PR DESCRIPTION
As already discussed here: https://github.com/brianegan/chewie/issues/387 I have added the new icons to the cupertino controls:
<img width="295" alt="Bildschirmfoto 2020-11-09 um 23 33 38" src="https://user-images.githubusercontent.com/18512224/98604864-c3ee6300-22e4-11eb-8a14-8f22a09a7e03.png">
