### PR TITLE
Fix dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.20.0 <2.0.0"
 
 dependencies:
-  video_player: ">=0.10.12+5 <2.0.0"
+  video_player: ^1.0.0
   cupertino_icons: ^1.0.0
   wakelock: ">=0.1.2 <0.3.0"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 
 dependencies:
   video_player: ">=0.10.12+5 <2.0.0"
-  cupertino_icons: ">=1.0.0 <2.0.0"
-  wakelock: ">=0.1.2 <1.0.0"
+  cupertino_icons: ^1.0.0
+  wakelock: ">=0.1.2 <0.3.0"
 
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   video_player: ^1.0.0
   cupertino_icons: ^1.0.0
-  wakelock: ^0.2.1+1
+  wakelock: ^0.2.0+1
 
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   video_player: ^1.0.0
   cupertino_icons: ^1.0.0
-  wakelock: ">=0.1.2 <0.3.0"
+  wakelock: ^0.2.1+1
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
@Ahmadre Just want to point out that it is not guaranteed that there will be no breaking changes until `1.0.0`. The Pub versioning would allow breaking changes when upgrading any **x** version in `0.x.y+z` or `x.y.z` when `x > 1`.

It is correct that there was no breaking change for `wakelock 0.2.0` ([changelog](https://pub.dev/packages/wakelock/changelog#020)) - only deprecations. However, I would probably want to remove the deprecations at some point.

---

About the `cupertino_icons` change: the caret syntax is identical in that case and the preferred syntax. See https://dart.dev/tools/pub/dependencies#caret-syntax.