### PR TITLE
Bump required Flutter version 1.20 -> 1.22

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/brianegan/chewie
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.20.0 <2.0.0"
+  flutter: ">=1.22.0 <2.0.0"
 
 dependencies:
   video_player: ^1.0.0


### PR DESCRIPTION
Since https://github.com/brianegan/chewie/commit/971c97aebaa976e3fd614426becc144d80d5f97a, chewie won't compile with Flutter version lower than 1.22. See https://github.com/flutter/flutter/commit/2032a448edd0da6460250f7d099d324a5989957f for more information. This commit bumps the required version in `pubspec.yaml` so app developers can upgrade their Flutter installation.