### PR TITLE
Fix duration called on null for cupertino controls

### DIFF
--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -221,7 +221,7 @@ class _CupertinoControlsState extends State<CupertinoControls> with SingleTicker
   }
 
   Expanded _buildHitArea() {
-    final bool isFinished = _latestValue.position >= _latestValue.duration;
+    final bool isFinished = _latestValue.duration != null && _latestValue.position >= _latestValue.duration;
 
     return Expanded(
       child: GestureDetector(


### PR DESCRIPTION
Fixes the duration is called on null error which appears when showing videos with cupertino controls.

Associated tickets: 

- https://github.com/brianegan/chewie/issues/229
- https://github.com/brianegan/chewie/issues/360
- https://github.com/brianegan/chewie/issues/306