### PR TITLE
fixed resizeToAvoidBottomPadding

### DIFF
--- a/example/lib/auto_rotate.dart
+++ b/example/lib/auto_rotate.dart
@@ -53,7 +53,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
             builder: (BuildContext context, Widget child) {
               return VideoScaffold(
                 child: Scaffold(
-                  resizeToAvoidBottomPadding: false,
+                  resizeToAvoidBottomInset: false,
                   body: Container(
                     alignment: Alignment.center,
                     color: Colors.black,

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -82,7 +82,7 @@ class ChewieState extends State<Chewie> {
     _ChewieControllerProvider controllerProvider,
   ) {
     return Scaffold(
-      resizeToAvoidBottomPadding: false,
+      resizeToAvoidBottomInset: false,
       body: Container(
         alignment: Alignment.center,
         color: Colors.black,


### PR DESCRIPTION
`resizeToAvoidBottomPadding` is deprecated since 1.19 and now removed.
It is replaced by `resizeToAvoidBottomInset `

https://api.flutter.dev/flutter/material/Scaffold/resizeToAvoidBottomPadding.html