### PR TITLE
Remove ios simulator warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ final playerWidget = Chewie(
 );
 ```
 
+## iOS warning 
+The video_player plugin used by chewie will only work in iOS simulators if you are on flutter 1.26.0 or above. You may need to switch to the beta channel `flutter channel beta`
+Please refer to this [issue](https://github.com/flutter/flutter/issues/14647).
+
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -80,9 +80,6 @@ final playerWidget = Chewie(
 );
 ```
 
-## iOS warning
-
-The video player plugin used by chewie is not functional on iOS simulators. An iOS device must be used during development/testing. Please refer to this [issue](https://github.com/flutter/flutter/issues/14647).
 
 
 ```


### PR DESCRIPTION
IOS simulator now works on  flutter 1.26.0. 

<img width="507" alt="Screen Shot 2021-02-14 at 7 13 34 PM" src="https://user-images.githubusercontent.com/17206638/107893463-5d876b00-6ef9-11eb-995c-293375f053ac.png">
