### PR TITLE
Animate all play/pause icons

### DIFF
--- a/lib/src/animated_play_pause.dart
+++ b/lib/src/animated_play_pause.dart
@@ -38,6 +38,12 @@ class AnimatedPlayPauseState extends State<AnimatedPlayPause>
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    animationController.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Center(
       child: AnimatedIcon(

--- a/lib/src/animated_play_pause.dart
+++ b/lib/src/animated_play_pause.dart
@@ -39,8 +39,8 @@ class AnimatedPlayPauseState extends State<AnimatedPlayPause>
 
   @override
   void dispose() {
-    super.dispose();
     animationController.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/src/animated_play_pause.dart
+++ b/lib/src/animated_play_pause.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// A widget that animates implicitly between a play and a pause icon.
+class AnimatedPlayPause extends StatefulWidget {
+  const AnimatedPlayPause({
+    Key? key,
+    required this.playing,
+    this.size,
+    this.color,
+  }) : super(key: key);
+
+  final double? size;
+  final bool playing;
+  final Color? color;
+
+  @override
+  State<StatefulWidget> createState() => AnimatedPlayPauseState();
+}
+
+class AnimatedPlayPauseState extends State<AnimatedPlayPause>
+    with SingleTickerProviderStateMixin {
+  late final animationController = AnimationController(
+    vsync: this,
+    value: widget.playing ? 1 : 0,
+    duration: const Duration(milliseconds: 400),
+  );
+
+  @override
+  void didUpdateWidget(AnimatedPlayPause oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.playing != oldWidget.playing) {
+      if (widget.playing) {
+        animationController.forward();
+      } else {
+        animationController.reverse();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: AnimatedIcon(
+        color: widget.color,
+        size: widget.size,
+        icon: AnimatedIcons.play_pause,
+        progress: animationController,
+      ),
+    );
+  }
+}

--- a/lib/src/center_play_button.dart
+++ b/lib/src/center_play_button.dart
@@ -1,0 +1,56 @@
+import 'package:chewie/src/animated_play_pause.dart';
+import 'package:flutter/material.dart';
+
+class CenterPlayButton extends StatelessWidget {
+  const CenterPlayButton({
+    Key? key,
+    required this.backgroundColor,
+    this.iconColor,
+    required this.show,
+    required this.isPlaying,
+    required this.isFinished,
+    this.onPressed,
+  }) : super(key: key);
+
+  final Color backgroundColor;
+  final Color? iconColor;
+  final bool show;
+  final bool isPlaying, isFinished;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.transparent,
+      child: Center(
+        child: AnimatedOpacity(
+          opacity: show ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 300),
+          child: GestureDetector(
+            child: Container(
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                borderRadius: BorderRadius.circular(48.0),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(12.0),
+                // Always set the iconSize on the IconButton, not on the Icon itself:
+                // https://github.com/flutter/flutter/issues/52980
+                child: IconButton(
+                  iconSize: 32,
+                  icon: isFinished
+                      ? Icon(Icons.replay, color: iconColor)
+                      : AnimatedPlayPause(
+                          color: iconColor,
+                          playing: isPlaying,
+                        ),
+                  onPressed: onPressed,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:chewie/src/animated_play_pause.dart';
+import 'package:chewie/src/center_play_button.dart';
 import 'package:chewie/src/chewie_player.dart';
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'package:chewie/src/cupertino_progress_bar.dart';
@@ -228,37 +229,13 @@ class _CupertinoControlsState extends State<CupertinoControls>
                   _hideStuff = false;
                 });
               },
-        child: Container(
-          color: Colors.transparent,
-          child: Center(
-            child: AnimatedOpacity(
-              opacity: !_latestValue.isPlaying && !_dragging ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 300),
-              child: GestureDetector(
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: widget.backgroundColor,
-                    borderRadius: BorderRadius.circular(48.0),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(12.0),
-                    child: IconButton(
-                        icon: isFinished
-                            ? Icon(Icons.replay,
-                                size: 32.0, color: widget.iconColor)
-                            : AnimatedPlayPause(
-                                size: 32.0,
-                                color: widget.iconColor,
-                                playing: controller.value.isPlaying,
-                              ),
-                        onPressed: () {
-                          _playPause();
-                        }),
-                  ),
-                ),
-              ),
-            ),
-          ),
+        child: CenterPlayButton(
+          backgroundColor: widget.backgroundColor,
+          iconColor: widget.iconColor,
+          isFinished: isFinished,
+          isPlaying: controller.value.isPlaying,
+          show: !_latestValue.isPlaying && !_dragging,
+          onPressed: _playPause,
         ),
       ),
     );

--- a/lib/src/cupertino_controls.dart
+++ b/lib/src/cupertino_controls.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
+import 'package:chewie/src/animated_play_pause.dart';
 import 'package:chewie/src/chewie_player.dart';
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'package:chewie/src/cupertino_progress_bar.dart';
@@ -42,12 +43,6 @@ class _CupertinoControlsState extends State<CupertinoControls>
   // We know that _chewieController is set in didChangeDependencies
   ChewieController get chewieController => _chewieController!;
   ChewieController? _chewieController;
-  late AnimationController playPauseIconAnimationController =
-      AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 400),
-    reverseDuration: const Duration(milliseconds: 400),
-  );
 
   @override
   Widget build(BuildContext context) {
@@ -251,11 +246,11 @@ class _CupertinoControlsState extends State<CupertinoControls>
                         icon: isFinished
                             ? Icon(Icons.replay,
                                 size: 32.0, color: widget.iconColor)
-                            : AnimatedIcon(
-                                icon: AnimatedIcons.play_pause,
-                                progress: playPauseIconAnimationController,
+                            : AnimatedPlayPause(
                                 size: 32.0,
-                                color: widget.iconColor),
+                                color: widget.iconColor,
+                                playing: controller.value.isPlaying,
+                              ),
                         onPressed: () {
                           _playPause();
                         }),
@@ -329,9 +324,9 @@ class _CupertinoControlsState extends State<CupertinoControls>
           left: 6.0,
           right: 6.0,
         ),
-        child: Icon(
-          controller.value.isPlaying ? Icons.pause : Icons.play_arrow,
-          color: iconColor,
+        child: AnimatedPlayPause(
+          color: widget.iconColor,
+          playing: controller.value.isPlaying,
         ),
       ),
     );

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:chewie/src/animated_play_pause.dart';
 import 'package:chewie/src/chewie_player.dart';
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'package:chewie/src/material_progress_bar.dart';
@@ -34,12 +35,6 @@ class _MaterialControlsState extends State<MaterialControls>
   ChewieController? _chewieController;
   // We know that _chewieController is set in didChangeDependencies
   ChewieController get chewieController => _chewieController!;
-  late AnimationController playPauseIconAnimationController =
-      AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 400),
-    reverseDuration: const Duration(milliseconds: 400),
-  );
 
   @override
   Widget build(BuildContext context) {
@@ -206,10 +201,9 @@ class _MaterialControlsState extends State<MaterialControls>
                     child: IconButton(
                         icon: isFinished
                             ? const Icon(Icons.replay, size: 32.0)
-                            : AnimatedIcon(
-                                icon: AnimatedIcons.play_pause,
-                                progress: playPauseIconAnimationController,
-                                size: 32.0,
+                            : AnimatedPlayPause(
+                                size: 32,
+                                playing: controller.value.isPlaying,
                               ),
                         onPressed: () {
                           _playPause();
@@ -310,8 +304,8 @@ class _MaterialControlsState extends State<MaterialControls>
           left: 12.0,
           right: 12.0,
         ),
-        child: Icon(
-          controller.value.isPlaying ? Icons.pause : Icons.play_arrow,
+        child: AnimatedPlayPause(
+          playing: controller.value.isPlaying,
         ),
       ),
     );
@@ -379,7 +373,6 @@ class _MaterialControlsState extends State<MaterialControls>
 
     setState(() {
       if (controller.value.isPlaying) {
-        playPauseIconAnimationController.reverse();
         _hideStuff = false;
         _hideTimer?.cancel();
         controller.pause();
@@ -389,13 +382,11 @@ class _MaterialControlsState extends State<MaterialControls>
         if (!controller.value.isInitialized) {
           controller.initialize().then((_) {
             controller.play();
-            playPauseIconAnimationController.forward();
           });
         } else {
           if (isFinished) {
             controller.seekTo(const Duration());
           }
-          playPauseIconAnimationController.forward();
           controller.play();
         }
       }

--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:chewie/src/animated_play_pause.dart';
+import 'package:chewie/src/center_play_button.dart';
 import 'package:chewie/src/chewie_player.dart';
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'package:chewie/src/material_progress_bar.dart';
@@ -184,35 +185,12 @@ class _MaterialControlsState extends State<MaterialControls>
             });
           }
         },
-        child: Container(
-          color: Colors.transparent,
-          child: Center(
-            child: AnimatedOpacity(
-              opacity: !_latestValue.isPlaying && !_dragging ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 300),
-              child: GestureDetector(
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).dialogBackgroundColor,
-                    borderRadius: BorderRadius.circular(48.0),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(12.0),
-                    child: IconButton(
-                        icon: isFinished
-                            ? const Icon(Icons.replay, size: 32.0)
-                            : AnimatedPlayPause(
-                                size: 32,
-                                playing: controller.value.isPlaying,
-                              ),
-                        onPressed: () {
-                          _playPause();
-                        }),
-                  ),
-                ),
-              ),
-            ),
-          ),
+        child: CenterPlayButton(
+          backgroundColor: Theme.of(context).dialogBackgroundColor,
+          isFinished: isFinished,
+          isPlaying: controller.value.isPlaying,
+          show: !_latestValue.isPlaying && !_dragging,
+          onPressed: _playPause,
         ),
       ),
     );


### PR DESCRIPTION
This PR adds an `AnimatedPlayPause` widget that encapsulates the animation. It implicitly animates the icon when it is rebuilt with a different `playing` argument.
Both `MaterialControls` and `CupertinoControls` can now simply use this widget without needing an `animationConttroller` on their own.

Screen recording:
https://user-images.githubusercontent.com/44171190/109505643-17a3d880-7a9d-11eb-9227-2dee7cc0862a.mp4

