### PR TITLE
chore: updated wakelock from 0.4.0 to 0.5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   video_player: ^2.0.0
-  wakelock: ^0.4.0
+  wakelock: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updated wakelock because more than one dependency im using is constrained to latest version