### PR TITLE
Fix the problem that the background image is revealed in the full screen

### DIFF
--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -41,7 +41,7 @@ class PlayerWithControls extends StatelessWidget {
         ChewieController chewieController, BuildContext context) {
       return Stack(
         children: <Widget>[
-          chewieController.placeholder ?? Container(),
+          _buildPlaceholder(chewieController, context) ?? Container(),
           Center(
             child: AspectRatio(
               aspectRatio: chewieController.aspectRatio ??
@@ -70,5 +70,22 @@ class PlayerWithControls extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget? _buildPlaceholder(
+      ChewieController chewieController, BuildContext context) {
+    if (chewieController.placeholder == null) return null;
+    const aspectRatio = 16 / 9;
+    final size = MediaQuery.of(context).size;
+    double width;
+    if (size.width < size.height) {
+      return chewieController.placeholder;
+    }
+    width = size.height * aspectRatio;
+
+    return Positioned.fill(
+        left: (size.width - width) / 2,
+        right: (size.width - width) / 2,
+        child: chewieController.placeholder!);
   }
 }


### PR DESCRIPTION
Before:![Simulator Screen Shot - iPhone 11 - 2021-04-27 at 21 01 46](https://user-images.githubusercontent.com/8716595/116245778-df1e3380-a79b-11eb-908e-174c82504253.png)
After:
![Simulator Screen Shot - iPhone 11 - 2021-04-27 at 21 04 42](https://user-images.githubusercontent.com/8716595/116246080-391ef900-a79c-11eb-8c26-c0d8a2a2f70e.png)
