### PR TITLE
_MaterialControlState._updateState: check mounted

### DIFF
--- a/lib/src/material_controls.dart
+++ b/lib/src/material_controls.dart
@@ -380,6 +380,7 @@ class _MaterialControlsState extends State<MaterialControls>
   }
 
   void _updateState() {
+    if (!mounted) return;
     setState(() {
       _latestValue = controller.value;
     });


### PR DESCRIPTION
I got the following crash:

```
Null check operator used on a null value

Stack trace:

#0 State.setState (package:flutter/src/widgets/framework.dart:1287)
#1 _MaterialControlsState._updateState (package:chewie_audio/src/material_controls.dart:227)
#2 ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:243)
#3 ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:309)
#4 VideoPlayerController.pause (package:video_player/video_player.dart:405)
#5 _VideoAppLifeCycleObserver.didChangeAppLifecycleState (package:video_player/video_player.dart:584)
#6 WidgetsBinding.handleAppLifecycleStateChanged (package:flutter/src/widgets/binding.dart:690)
#7 ServicesBinding._handleLifecycleMessage (package:flutter/src/services/binding.dart:192)
#8 BasicMessageChannel.setMessageHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:73)
#9 BasicMessageChannel.setMessageHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:72)
#10 _DefaultBinaryMessenger.handlePlatformMessage (package:flutter/src/services/binding.dart:284)
#11 _invoke3.<anonymous closure> (dart:ui/hooks.dart:221)
#12 _rootRun (dart:async/zone.dart:1354)
#13 _CustomZone.run (dart:async/zone.dart:1258)
#14 _CustomZone.runGuarded (dart:async/zone.dart:1162)
#15 _invoke3 (dart:ui/hooks.dart:220)
#16 PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:457)
#17 _dispatchPlatformMessage (dart:ui/hooks.dart:90)
```

I noticed that `_CupertinoControlsState._updateState` checks for `mounted` but somehow `_MaterialControlState._updateState` does not. The earlier check was introduced with https://github.com/brianegan/chewie/commit/afeb2241229186a2d029c76c30456ae1fa8fce67

So I added the same check here.
