### PR TITLE
Add useRootNavigator property to ChewieController

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -70,7 +70,10 @@ class ChewieState extends State<Chewie> {
       _isFullScreen = true;
       await _pushFullScreenWidget(context);
     } else if (_isFullScreen) {
-      Navigator.of(context, rootNavigator: true).pop();
+      Navigator.of(
+        context,
+        rootNavigator: widget.controller.useRootNavigator,
+      ).pop();
       _isFullScreen = false;
     }
   }
@@ -147,7 +150,10 @@ class ChewieState extends State<Chewie> {
       Wakelock.enable();
     }
 
-    await Navigator.of(context, rootNavigator: true).push(route);
+    await Navigator.of(
+      context,
+      rootNavigator: widget.controller.useRootNavigator,
+    ).push(route);
     _isFullScreen = false;
     widget.controller.exitFullScreen();
 
@@ -246,6 +252,7 @@ class ChewieController extends ChangeNotifier {
     this.allowFullScreen = true,
     this.allowMuting = true,
     this.allowPlaybackSpeedChanging = true,
+    this.useRootNavigator = true,
     this.playbackSpeeds = const [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
     this.systemOverlaysOnEnterFullScreen,
     this.deviceOrientationsOnEnterFullScreen,
@@ -284,6 +291,7 @@ class ChewieController extends ChangeNotifier {
     bool? allowFullScreen,
     bool? allowMuting,
     bool? allowPlaybackSpeedChanging,
+    bool? useRootNavigator,
     List<double>? playbackSpeeds,
     List<SystemUiOverlay>? systemOverlaysOnEnterFullScreen,
     List<DeviceOrientation>? deviceOrientationsOnEnterFullScreen,
@@ -325,6 +333,7 @@ class ChewieController extends ChangeNotifier {
       allowMuting: allowMuting ?? this.allowMuting,
       allowPlaybackSpeedChanging:
           allowPlaybackSpeedChanging ?? this.allowPlaybackSpeedChanging,
+      useRootNavigator: useRootNavigator ?? this.useRootNavigator,
       playbackSpeeds: playbackSpeeds ?? this.playbackSpeeds,
       systemOverlaysOnEnterFullScreen: systemOverlaysOnEnterFullScreen ??
           this.systemOverlaysOnEnterFullScreen,
@@ -438,6 +447,9 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines if the playback speed control should be shown
   final bool allowPlaybackSpeedChanging;
+
+  /// Defines if push/pop navigations use the rootNavigator
+  final bool useRootNavigator;
 
   /// Defines the set of allowed playback speeds user can change
   final List<double> playbackSpeeds;

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -483,7 +483,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
         final chosenSpeed = await showCupertinoModalPopup<double>(
           context: context,
           semanticsDismissible: true,
-          useRootNavigator: true,
+          useRootNavigator: chewieController.useRootNavigator,
           builder: (context) => _PlaybackSpeedDialog(
             speeds: chewieController.playbackSpeeds,
             selected: _latestValue.playbackSpeed,

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -197,7 +197,7 @@ class _MaterialControlsState extends State<MaterialControls>
             await showModalBottomSheet<OptionItem>(
               context: context,
               isScrollControlled: true,
-              useRootNavigator: true,
+              useRootNavigator: chewieController.useRootNavigator,
               builder: (context) => OptionsDialog(
                 options: options,
                 cancelButtonText:
@@ -370,7 +370,7 @@ class _MaterialControlsState extends State<MaterialControls>
     final chosenSpeed = await showModalBottomSheet<double>(
       context: context,
       isScrollControlled: true,
-      useRootNavigator: true,
+      useRootNavigator: chewieController.useRootNavigator,
       builder: (context) => PlaybackSpeedDialog(
         speeds: chewieController.playbackSpeeds,
         selected: _latestValue.playbackSpeed,

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -183,7 +183,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
             await showModalBottomSheet<OptionItem>(
               context: context,
               isScrollControlled: true,
-              useRootNavigator: true,
+              useRootNavigator: chewieController.useRootNavigator,
               builder: (context) => OptionsDialog(
                 options: options,
                 cancelButtonText:
@@ -360,7 +360,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
     final chosenSpeed = await showModalBottomSheet<double>(
       context: context,
       isScrollControlled: true,
-      useRootNavigator: true,
+      useRootNavigator: chewieController.useRootNavigator,
       builder: (context) => PlaybackSpeedDialog(
         speeds: chewieController.playbackSpeeds,
         selected: _latestValue.playbackSpeed,


### PR DESCRIPTION
The package always uses rootNavigator for Pushing Fullscreen Page, showing controls popup or bottom sheets, etc. But, there are cases where this behavior is undesirable and cause issues such as popping the wrong page on pressing back button (Especially when using custom navigation/routing packages such as [auto_route](https://pub.dev/packages/auto_route) or nested navigators).

I have added a useRootNavigator property to ChewieController such that the default behavior is same as before but users can configure chewie to not use rootNavigator.