### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cupertino_icons: ^1.0.3
   flutter:
     sdk: flutter
-  provider: ^5.0.0
+  provider: ^6.0.0
   video_player: ^2.1.5
   wakelock: ^0.5.2
 


### PR DESCRIPTION
Many packages are now using Provider 6.0.0 which creates a conflict with chewie which is using provider 5.0.0 in my project, checked and tested using provider 6.0.0 requires no changes and works just fine.
Please approve the change.
Thanks