### PR TITLE
Add support for provider version 6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cupertino_icons: ^1.0.3
   flutter:
     sdk: flutter
-  provider: ^5.0.0
+  provider: '>=5.0.0 <7.0.0'
   video_player: ^2.1.5
   wakelock: ^0.5.2
 


### PR DESCRIPTION
Allows Provider version 6 to be used in conjunction with Chewie.

Some libraries are starting to update to use v6 of provider (such as `flutter_bloc: ^7.2.0`) which throws the following error on `pub get`:

```
Because no versions of chewie match >1.2.2 <2.0.0 and chewie 1.2.2 depends on provider ^5.0.0, chewie ^1.2.2 requires provider ^5.0.0.
And because flutter_bloc >=7.2.0 depends on provider ^6.0.0, chewie ^1.2.2 is incompatible with flutter_bloc >=7.2.0.
```

The breaking changes in the [provider changelog](https://github.com/rrousselGit/provider/blob/master/CHANGELOG.md#600) only talk about optional providers of which Chewie doesn't use any so it should be safe to use provider 6 with chewie. Example app still appears to work as expected with provider v6. Have added `<7` to safeguard against breaking changes in future unreleased versions of Provider.